### PR TITLE
Remove package name in stream opening

### DIFF
--- a/src/grpc_client_stream.erl
+++ b/src/grpc_client_stream.erl
@@ -227,13 +227,12 @@ new_stream(Connection, Service, Rpc, Encoder, Options) ->
     Metadata = proplists:get_value(metadata, Options, #{}),
     TransportOptions = proplists:get_value(http2_options, Options, []),
     {ok, StreamId} = grpc_client_connection:new_stream(Connection, TransportOptions),
-    Package = Encoder:get_package_name(),
     RpcDef = Encoder:find_rpc_def(Service, Rpc),
     %% the gpb rpc def has 'input', 'output' etc.
     %% All the information is combined in 1 map, 
     %% which is is the state of the gen_server.
     RpcDef#{stream_id => StreamId,
-            package => [atom_to_list(Package),$.],
+            package => [],
             service => Service,
             rpc => Rpc,
             queue => queue:new(),


### PR DESCRIPTION
Apparently package name duplicates, which I introduced here https://github.com/Bluehouse-Technology/grpc_client/issues/7 , can be solved by this PR.

Definitely it's need to be researched to have a solution which could work for all protocol buffers definitions and not only the one I had in the issue.
