### PR TITLE
Add scripts to publish packages to hex automatically

### DIFF
--- a/.github/workflows/publish-to-hex.yml
+++ b/.github/workflows/publish-to-hex.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out
+        uses: actions/checkout@v2
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v1
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/src/grpc_client.app.src
+++ b/src/grpc_client.app.src
@@ -1,6 +1,6 @@
 {application,grpc_client,
  [{description,"gRPC client in Erlang"},
-  {vsn,"0.2.0"},
+  {vsn,"git"},
   {modules,[]},
   {registered, []},
   {env, []},


### PR DESCRIPTION
In this PR, I use GitHub Actions erlangpack/github-action@v1 and actions/checkout@v2 to automate hex package publishing.

@cmullaparthi You have to generate Hex API key via this [link](https://hex.pm/dashboard/keys) and place it in Repository secrets.


![](https://user-images.githubusercontent.com/20479699/119797886-3b948000-bf0d-11eb-8ff3-1fc851da4c06.png)